### PR TITLE
Add failing JSON schema validation test

### DIFF
--- a/src/test/java/com/example/calculationservice/Unittests/CalcServiceTest.java
+++ b/src/test/java/com/example/calculationservice/Unittests/CalcServiceTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.File;
 import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -59,6 +60,15 @@ public class CalcServiceTest {
         } catch (Exception e) {
             fail("Das JSON-Dokument entspricht nicht dem Schema: " + e.getMessage());
         }
+    }
+
+    @Test
+    public void testInvalidJsonThrowsException() {
+        String schemaFilePath = "person_schema.json";
+        String jsonFilePath = "invalid_person.json";
+
+        assertThrows(Exception.class,
+                () -> JsonSchemaValidator.validateJson(schemaFilePath, jsonFilePath));
     }
 }
 

--- a/src/test/resources/invalid_person.json
+++ b/src/test/resources/invalid_person.json
@@ -1,0 +1,4 @@
+{
+  "firstName": "John",
+  "age": 30
+}


### PR DESCRIPTION
## Summary
- test JsonSchemaValidator for invalid data using assertThrows
- add invalid JSON sample missing required fields

## Testing
- `sh mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684a91398b908321a6eacb9d34b0689a